### PR TITLE
FOR DISCUSSION: Mods to make nyc work properly for bedrock modules.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
-        npm install
         cd test
         npm install
     - name: Run test with Node.js ${{ matrix.node-version }}
@@ -43,3 +42,34 @@ jobs:
     - run: npm install
     - name: Run eslint
       run: npm run lint
+  coverage:
+    needs: [test-node]
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:3.6
+        ports:
+          - 27017:27017
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+        cd test
+        npm install
+    - name: Generate coverage report
+      run: |
+        cd test
+        npm run coverage-ci
+      env:
+        CI: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./test/coverage.lcov
+        fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*.lcov
 *.log
 *.sw[nop]
 *~
+.nyc_output
 .project
 .settings
 .vscode

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1-0",
   "private": true,
   "scripts": {
-    "test": "node --preserve-symlinks test.js test"
+    "test": "node --preserve-symlinks test.js test",
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=text-lcov npm test > coverage.lcov",
+    "coverage-report": "nyc report"
   },
   "dependencies": {
     "apisauce": "^1.1.1",
@@ -29,6 +32,14 @@
     "bedrock-test": "^5.1.0",
     "bedrock-validation": "^4.2.0",
     "bedrock-zcap-storage": "^2.0.0",
+    "cross-env": "^7.0.2",
+    "nyc": "^15.0.1",
     "sinon": "^9.0.0"
+  },
+  "nyc": {
+    "excludeNodeModules": false,
+    "include": [
+      "node_modules/bedrock-profile-http/**"
+    ]
   }
 }


### PR DESCRIPTION
The good news is, we have A way of getting coverage on a Bedrock module.

Here's a report: https://codecov.io/gh/digitalbazaar/bedrock-profile-http/tree/e3f64b57bec39764f23303461b0860c2798bef7b/lib

The bad news is that nyc doesn't like working with stuff in node_modules generally and detests symlinks all-together.

See this: https://github.com/istanbuljs/nyc/issues/1301#issuecomment-610919755

I will highlight the specific changes in files.