### PR TITLE
CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
-        npm install
         cd test
         npm install
     - name: Run test with Node.js ${{ matrix.node-version }}
@@ -43,3 +42,34 @@ jobs:
     - run: npm install
     - name: Run eslint
       run: npm run lint
+  coverage:
+    needs: [test-node]
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:3.6
+        ports:
+          - 27017:27017
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+        cd test
+        npm install
+    - name: Generate coverage report
+      run: |
+        cd test
+        npm run coverage-ci
+      env:
+        CI: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./test/coverage.lcov
+        fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on: [push]
 jobs:
   test-node:
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:3.6
+        ports:
+          - 27017:27017
     strategy:
       matrix:
         node-version: [10.x, 12.x]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Bedrock Node.js CI
+
+on: [push]
+
+jobs:
+  test-node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+        npm install
+        cd test
+        npm install
+    - name: Run test with Node.js ${{ matrix.node-version }}
+      run: npm test
+      env:
+        CI: true
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Run eslint
+      run: npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,9 @@ jobs:
         cd test
         npm install
     - name: Run test with Node.js ${{ matrix.node-version }}
-      run: npm test
+      run: |
+        cd test
+        npm test
       env:
         CI: true
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*.lcov
 *.log
 *.sw[nop]
 *~
+.nyc_output
 .project
 .settings
 .vscode

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "4.0.1-0",
   "description": "Bedrock Profile HTTP API",
   "main": "./lib",
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint lib/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalbazaar/bedrock-profile-http"

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1-0",
   "private": true,
   "scripts": {
-    "test": "node --preserve-symlinks test.js test"
+    "test": "node --preserve-symlinks test.js test",
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=text-lcov npm test > coverage.lcov",
+    "coverage-report": "nyc report"
   },
   "dependencies": {
     "apisauce": "^1.1.1",
@@ -29,6 +32,14 @@
     "bedrock-test": "^5.1.0",
     "bedrock-validation": "^4.2.0",
     "bedrock-zcap-storage": "^2.0.0",
+    "cross-env": "^7.0.2",
+    "nyc": "^15.0.1",
     "sinon": "^9.0.0"
+  },
+  "nyc": {
+    "excludeNodeModules": false,
+    "include": [
+      "node_modules/bedrock-profile-http/**"
+    ]
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -24,7 +24,7 @@
     "bedrock-profile": "^4.0.0",
     "bedrock-profile-http": "file:..",
     "bedrock-security-context": "^3.0.0",
-    "bedrock-server": "digitalbazaar/bedrock-server#localhost",
+    "bedrock-server": "^2.6.0",
     "bedrock-ssm-mongodb": "^2.0.1",
     "bedrock-test": "^5.1.0",
     "bedrock-validation": "^4.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -40,6 +40,9 @@
     "excludeNodeModules": false,
     "include": [
       "node_modules/bedrock-profile-http/**"
+    ],
+    "exclude": [
+      "node_modules/bedrock-profile-http/node_modules/**"
     ]
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -24,7 +24,7 @@
     "bedrock-profile": "^4.0.0",
     "bedrock-profile-http": "file:..",
     "bedrock-security-context": "^3.0.0",
-    "bedrock-server": "^2.4.1",
+    "bedrock-server": "digitalbazaar/bedrock-server#localhost",
     "bedrock-ssm-mongodb": "^2.0.1",
     "bedrock-test": "^5.1.0",
     "bedrock-validation": "^4.2.0",


### PR DESCRIPTION
We won't need to review this stuff 1000 times as we enable CI etc on the modules, but I wanted everyone to see roughly what is involved.

Turns out there is a newish `excludeNodeModules` feature in `nyc` that provides support for the way we test bedrock modules.  See the `nyc` section of the `package.json` file in the test folder (part of this PR).

I really like the way we are able to add services to CI test harness like mongo/redis using `services` as with docker-compose.

Coverage reports are uploaded to codecov.io
https://codecov.io/gh/digitalbazaar/bedrock-profile-http/commits

Codecov.io is having some difficulties right now apparently in relation to changes that github is making.  You may get a 500 error or 'github api not authorized' sort of errors when attempting to view coverage reports.  Just refresh the page a few times and it should work.

As before, devs will still be able to generate/view local versions of the coverage report.  For bedrock modules like this one:
```
cd test
npm install
npm run coverage
firefox coverage/lcov-report/index.html
```