### PR TITLE
Correct typo Account Query not Accout Query.

### DIFF
--- a/schemas/bedrock-profile-http.js
+++ b/schemas/bedrock-profile-http.js
@@ -15,7 +15,7 @@ const profile = {
 
 // this should match query objects with an account in them
 const accountQuery = {
-  title: 'Accout Query',
+  title: 'Account Query',
   type: 'object',
   required: ['account'],
   additionalProperties: false,

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -85,7 +85,7 @@ describe('bedrock-profile-http', () => {
       result.status.should.equal(400);
       result.ok.should.equal(false);
       result.data.message.should.equal(
-        'A validation error occured in the \'Accout Query\' validator.');
+        'A validation error occured in the \'Account Query\' validator.');
     });
     it('throws error when account is not authorized', async () => {
       let result;
@@ -294,7 +294,7 @@ describe('bedrock-profile-http', () => {
       result.status.should.equal(400);
       result.ok.should.equal(false);
       result.data.message.should.equal(
-        'A validation error occured in the \'Accout Query\' validator.');
+        'A validation error occured in the \'Account Query\' validator.');
     });
     it('throws error when account is not authorized', async () => {
       const {account: {id: account}} = accounts['alpha@example.com'];
@@ -371,7 +371,7 @@ describe('bedrock-profile-http', () => {
       result.status.should.equal(400);
       result.ok.should.equal(false);
       result.data.message.should.equal(
-        'A validation error occured in the \'Accout Query\' validator.');
+        'A validation error occured in the \'Account Query\' validator.');
     });
     it('throws error when account is not authorized', async () => {
       const {account: {id: account}} = accounts['alpha@example.com'];


### PR DESCRIPTION
My apologies about this, I made a small typo in the `Account Query` validator awhile back where I spelled the `title` of the validator 'Accout Query' when it should be 'Account Query'. This PR fixes that issue, my poor spelling however remains unchanged. I am considering typing classes. 