### PR TITLE
Decode profile and account uris at the get profileAgents endpoint.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -94,7 +94,14 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     validate({query: 'bedrock-profile-http.profileAgents'}),
     asyncHandler(async (req, res) => {
       const {account: {id: accountId}} = (req.user || {});
-      const {account, profile} = req.query;
+      let {account, profile} = req.query;
+      if(account) {
+        account = decodeURIComponent(account);
+      }
+      if(profile) {
+        profile = decodeURIComponent(profile);
+      }
+
       // TODO: Add permissions to allow access for admin
       if(account !== accountId) {
         throw new BedrockError(


### PR DESCRIPTION
This is a fix to this [error](https://gist.github.com/JSAssassin/c0a79a43fb3cb8b5d97da6aa71a004fa) that I get when testing veres-issuer flow. 


