### PR TITLE
Add checks for get & delete profileAgent by id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-profile-http ChangeLog
 
+## 5.0.2 - TBD
+
+### Fixed
+- Account restrictions on GET routes.profileAgent.
+- Account restrictions on DELETE routes.profileAgent.
+- Restrictions on POST routes.profileAgentClaim.
+- Account restrictions on POST routes.profileAgentCapabilities.
+- Account restrictions on POST routes.profileAgentCapabilitySet.
+
 ## 5.0.1 - 2020-12-14
 
 ### Changed

--- a/lib/http.js
+++ b/lib/http.js
@@ -121,17 +121,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     validate({query: 'bedrock-profile-http.account'}),
     asyncHandler(async (req, res) => {
       const {account: {id: accountId}} = (req.user || {});
-      const {account} = req.query;
+      const {profileAgentId} = req.params;
+      // this throws NotFoundError
+      const profileAgentRecord = await profileAgents.get({id: profileAgentId});
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(account !== accountId) {
+      if(profileAgentRecord.profileAgent.account !== accountId) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',
           {httpStatusCode: 403, public: true});
       }
-      const {profileAgentId} = req.params;
-      const profileAgentRecord = await profileAgents.get({id: profileAgentId});
       res.json(profileAgentRecord);
     }));
 
@@ -142,16 +142,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     validate({query: 'bedrock-profile-http.account'}),
     asyncHandler(async (req, res) => {
       const {account: {id: accountId}} = (req.user || {});
-      const {account} = req.query;
+      const {profileAgentId} = req.params;
+      // this throws NotFoundError
+      const profileAgentRecord = await profileAgents.get({id: profileAgentId});
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(account !== accountId) {
+      if(profileAgentRecord.profileAgent.account !== accountId) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',
           {httpStatusCode: 403, public: true});
       }
-      const {profileAgentId} = req.params;
       await profileAgents.remove({id: profileAgentId});
       res.status(204).end();
     }));

--- a/lib/http.js
+++ b/lib/http.js
@@ -126,7 +126,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const profileAgentRecord = await profileAgents.get({id: profileAgentId});
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(profileAgentRecord.profileAgent.account !== accountId) {
+      if(!(profileAgentRecord.profileAgent.account &&
+        profileAgentRecord.profileAgent.account === accountId)) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',

--- a/lib/http.js
+++ b/lib/http.js
@@ -144,10 +144,10 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {account: {id: accountId}} = (req.user || {});
       const {profileAgentId} = req.params;
       // this throws NotFoundError
-      const profileAgentRecord = await profileAgents.get({id: profileAgentId});
+      const {profileAgent} = await profileAgents.get({id: profileAgentId});
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(profileAgentRecord.profileAgent.account !== accountId) {
+      if(profileAgent.account !== accountId) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',

--- a/lib/http.js
+++ b/lib/http.js
@@ -124,14 +124,32 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {profileAgentId} = req.params;
       // this throws NotFoundError
       const profileAgentRecord = await profileAgents.get({id: profileAgentId});
+      const {profileAgent} = profileAgentRecord;
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(!(profileAgentRecord.profileAgent.account &&
-        profileAgentRecord.profileAgent.account === accountId)) {
-        throw new BedrockError(
-          'The "account" is not authorized.',
-          'NotAllowedError',
-          {httpStatusCode: 403, public: true});
+      // if a profileAgent has an associated account then only allow
+      // matching accounts
+      if(profileAgent && profileAgent.account) {
+        if(!profileAgent.account === accountId) {
+          throw new BedrockError(
+            'The "account" is not authorized.',
+            'NotAllowedError',
+            {httpStatusCode: 403, public: true});
+        }
+      }
+      // integrations & unclaimed profileAgents don't have an account
+      if(profileAgent && !profileAgent.account) {
+        const agents = await profileAgents.getAll({accountId});
+        const profileMember = agents.find(a =>
+          (a.profileAgent && a.profileAgent.profile === profileAgent.profile));
+        // this will throw if you try to get an integration or an unclaimed
+        // profileAgent and you're not a member of that profile
+        if(!profileMember) {
+          throw new BedrockError(
+            'The "account" is not authorized.',
+            'NotAllowedError',
+            {httpStatusCode: 403, public: true});
+        }
       }
       res.json(profileAgentRecord);
     }));

--- a/lib/http.js
+++ b/lib/http.js
@@ -172,9 +172,11 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
           });
       }
       const {profileAgentId} = req.params;
-      const {profileAgent} = await profileAgents.get({id: profileAgentId});
-
-      if(profileAgent.account === account) {
+      const {profileAgent, secrets} = await profileAgents.get(
+        {id: profileAgentId, includeSecrets: true});
+      // a profileAgent is claimed if there is an account set or
+      // it has a token for an integration
+      if(profileAgent.account || secrets.token) {
         // account already set properly, send affirmative response
         return res.status(204).end();
       }

--- a/lib/http.js
+++ b/lib/http.js
@@ -245,7 +245,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {profileAgentId} = req.params;
       const {profileAgent} = await profileAgents.get({id: profileAgentId});
       // TODO: Add permissions to allow access for admin
-      if(profileAgent.account !== accountId) {
+      if(!(profileAgent.account && profileAgent.account === accountId)) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',

--- a/lib/http.js
+++ b/lib/http.js
@@ -183,7 +183,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
             profileAgentId
           });
       }
-      // a profileAgent is claimed if there is an account set
+      // `profileAgent` already claimed by requested account if `account` is set
       if(profileAgent.account) {
         // account already set properly, send affirmative response
         return res.status(204).end();

--- a/lib/http.js
+++ b/lib/http.js
@@ -177,7 +177,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // you can not claim an integration
       if(secrets.token) {
         throw new BedrockError(
-          'profileAgent can not be claimed.', 'NotAllowedError', {
+          'The given profile agent cannot be claimed.', 'NotAllowedError', {
             httpStatusCode: 400,
             public: true,
             profileAgentId

--- a/lib/http.js
+++ b/lib/http.js
@@ -174,9 +174,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {profileAgentId} = req.params;
       const {profileAgent, secrets} = await profileAgents.get(
         {id: profileAgentId, includeSecrets: true});
-      // a profileAgent is claimed if there is an account set or
-      // it has a token for an integration
-      if(profileAgent.account || secrets.token) {
+      // you can not claim an integration
+      if(secrets.token) {
+        throw new BedrockError(
+          'profileAgent can not be claimed.', 'NotAllowedError', {
+            httpStatusCode: 400,
+            public: true,
+            profileAgentId
+          });
+      }
+      // a profileAgent is claimed if there is an account set
+      if(profileAgent.account) {
         // account already set properly, send affirmative response
         return res.status(204).end();
       }

--- a/lib/http.js
+++ b/lib/http.js
@@ -211,7 +211,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {profileAgent, secrets} = await profileAgents.get(
         {id: profileAgentId, includeSecrets: true});
       // TODO: Add permissions to allow access for admin
-      if(profileAgent.account !== accountId) {
+      if(!(profileAgent.account && profileAgent.account === accountId)) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',

--- a/lib/http.js
+++ b/lib/http.js
@@ -147,7 +147,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {profileAgent} = await profileAgents.get({id: profileAgentId});
       // FIXME: Use http-sigs and zcaps for
       // TODO: Add permissions to allow access for admin
-      if(profileAgent.account !== accountId) {
+      if(!(profileAgent.account && profileAgent.account === accountId)) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',

--- a/lib/http.js
+++ b/lib/http.js
@@ -196,17 +196,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     validate('bedrock-profile-http.delegateCapability'),
     asyncHandler(async (req, res) => {
       const {account: {id: accountId}} = (req.user || {});
-      const {invoker, account} = req.body;
+      const {invoker} = req.body;
+      const {profileAgentId} = req.params;
+      const {profileAgent, secrets} = await profileAgents.get(
+        {id: profileAgentId, includeSecrets: true});
       // TODO: Add permissions to allow access for admin
-      if(account !== accountId) {
+      if(profileAgent.account !== accountId) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',
           {httpStatusCode: 403, public: true});
       }
-      const {profileAgentId} = req.params;
-      const {profileAgent, secrets} = await profileAgents.get(
-        {id: profileAgentId, includeSecrets: true});
       const now = Date.now();
       const ttl = config['profile-http'].zcap.ttl;
       const expires = new Date(now + ttl).toISOString();
@@ -231,17 +231,16 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     }),
     asyncHandler(async (req, res) => {
       const {account: {id: accountId}} = (req.user || {});
-      const {account} = req.query;
       const {zcaps} = req.body;
+      const {profileAgentId} = req.params;
+      const {profileAgent} = await profileAgents.get({id: profileAgentId});
       // TODO: Add permissions to allow access for admin
-      if(account !== accountId) {
+      if(profileAgent.account !== accountId) {
         throw new BedrockError(
           'The "account" is not authorized.',
           'NotAllowedError',
           {httpStatusCode: 403, public: true});
       }
-      const {profileAgentId} = req.params;
-      const {profileAgent} = await profileAgents.get({id: profileAgentId});
 
       profileAgent.sequence++;
       // replace existing zcaps

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -542,6 +542,7 @@ describe('bedrock-profile-http', () => {
       let result;
       let error;
       try {
+        await helpers.stubPassport({email: mockData.emails.failMail});
         result = await api.post(`/profile-agents/${profileAgentId}` +
           '/capabilities/delegate', {invoker: did, account: wrongAccount});
       } catch(e) {
@@ -680,6 +681,7 @@ describe('bedrock-profile-http', () => {
       let result;
       let error;
       try {
+        await helpers.stubPassport({email: mockData.emails.failMail});
         result = await api.post(`/profile-agents/${profileAgentId}` +
           `/capability-set?account=${wrongAccount}`, {zcaps});
       } catch(e) {

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -22,7 +22,6 @@ describe('bedrock-profile-http', () => {
   let passportStub;
   before(async () => {
     await helpers.prepareDatabase(mockData);
-    passportStub = await helpers.stubPassport();
     accounts = mockData.accounts;
     zcaps = mockData.zcaps;
     api = create({
@@ -30,6 +29,9 @@ describe('bedrock-profile-http', () => {
       headers: {Accept: 'application/ld+json, application/json'},
       httpsAgent: new https.Agent({rejectUnauthorized: false})
     });
+  });
+  beforeEach(async () => {
+    passportStub = await helpers.stubPassport();
   });
   after(async () => {
     passportStub.restore();
@@ -349,6 +351,7 @@ describe('bedrock-profile-http', () => {
       let result;
       let error;
       try {
+        await helpers.stubPassport({email: mockData.emails.failMail});
         result = await api.get(`/profile-agents/${profileAgentId}` +
           `?account=${wrongAccount}`);
       } catch(e) {
@@ -432,6 +435,7 @@ describe('bedrock-profile-http', () => {
       let result;
       let error;
       try {
+        await helpers.stubPassport({email: mockData.emails.failMail});
         result = await api.delete(`/profile-agents/${profileAgentId}` +
           `?account=${wrongAccount}`);
       } catch(e) {

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -12,7 +12,15 @@ const mockData = require('./mock.data');
 
 exports.stubPassport = async ({email = 'alpha@example.com'} = {}) => {
   const actors = await exports.getActors(mockData);
-  const passportStub = sinon.stub(brPassport, 'optionallyAuthenticated');
+  if(brPassport.optionallyAuthenticated.restore) {
+    brPassport.optionallyAuthenticated.restore();
+  }
+  let passportStub = brPassport.optionallyAuthenticated;
+  try {
+    passportStub = sinon.stub(brPassport, 'optionallyAuthenticated');
+  } catch(e) {
+    console.error('Stub failed', e);
+  }
   passportStub.callsFake((req, res, next) => {
     req.user = {
       account: mockData.accounts[email].account,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -12,14 +12,25 @@ module.exports = data;
 
 const zcaps = data.zcaps = {};
 const accounts = data.accounts = {};
+const emails = data.emails = {};
 
 // regular permissions
-const email = 'alpha@example.com';
-accounts[email] = {};
-accounts[email].account = createAccount(email);
-accounts[email].meta = {};
-accounts[email].meta.sysResourceRole = [{
+emails.alpha = 'alpha@example.com';
+accounts[emails.alpha] = {};
+accounts[emails.alpha].account = createAccount(emails.alpha);
+accounts[emails.alpha].meta = {};
+accounts[emails.alpha].meta.sysResourceRole = [{
   sysRole: 'bedrock-test.regular',
+  // FIXME: had to enable admin rights to create keyStore
+  // generateResource: 'id'
+}];
+
+emails.failMail = 'auth-test@example.com';
+accounts[emails.failMail] = {};
+accounts[emails.failMail].account = createAccount(emails.failMail);
+accounts[emails.failMail].meta = {};
+accounts[emails.failMail].meta.sysResourceRole = [{
+  sysRole: 'bedrock-test.fail',
   // FIXME: had to enable admin rights to create keyStore
   // generateResource: 'id'
 }];

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -21,8 +21,7 @@ accounts[emails.alpha].account = createAccount(emails.alpha);
 accounts[emails.alpha].meta = {};
 accounts[emails.alpha].meta.sysResourceRole = [{
   sysRole: 'bedrock-test.regular',
-  // FIXME: had to enable admin rights to create keyStore
-  // generateResource: 'id'
+  generateResource: 'id'
 }];
 
 emails.failMail = 'auth-test@example.com';
@@ -31,8 +30,7 @@ accounts[emails.failMail].account = createAccount(emails.failMail);
 accounts[emails.failMail].meta = {};
 accounts[emails.failMail].meta.sysResourceRole = [{
   sysRole: 'bedrock-test.regular',
-  // FIXME: had to enable admin rights to create keyStore
-  // generateResource: 'id'
+  generateResource: 'id'
 }];
 
 function createAccount(email) {

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -30,7 +30,7 @@ accounts[emails.failMail] = {};
 accounts[emails.failMail].account = createAccount(emails.failMail);
 accounts[emails.failMail].meta = {};
 accounts[emails.failMail].meta.sysResourceRole = [{
-  sysRole: 'bedrock-test.fail',
+  sysRole: 'bedrock-test.regular',
   // FIXME: had to enable admin rights to create keyStore
   // generateResource: 'id'
 }];

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
+    "debug": "node --preserve-symlinks test.js test --log-level debug",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcov npm test",
     "coverage-report": "nyc report"


### PR DESCRIPTION
Addresses: https://github.com/digitalbazaar/bedrock-profile-http/issues/31

Adds guards to the following routes:

- [x] GET routes.profileAgent
- [x] DELETE routes.profileAgent
- [x] POST routes.profileAgentClaim
- [x] POST routes.profileAgentCapabilities
- [x] POST routes.profileAgentCapabilitySet
